### PR TITLE
Preventing resource deletes by default

### DIFF
--- a/lib/actions/ResourcesDeploy.js
+++ b/lib/actions/ResourcesDeploy.js
@@ -58,6 +58,11 @@ usage: serverless resources deploy`,
             option:      'noExeCf',
             shortcut:    'c',
             description: 'Optional - Don\'t execute CloudFormation, just generate it. Default: false'
+          },
+          {
+            option:      'allowDeletes',
+            shortcut:    'a',
+            description: 'Optional - Allow deletes, if you have prevented them by default. Default: false'
           }
         ]
       });
@@ -215,14 +220,21 @@ usage: serverless resources deploy`,
             _this.cfTemplate
             )
             .then(function(templateUrl) {
+              let project = _this.S.state.getProject();
+
+              if (_this.evt.options.allowDeletes && !regionVars.preventResourceDeletes) {
+                console.log('Warning: allowDeletes flag requires you to set the preventResourceDeletes variable to true');
+              }
 
               // Trigger CF Stack Create/Update
               return _this.CF.sCreateOrUpdateResourcesStack(
-                _this.S.state.getProject().name,
+                project.name,
                 _this.evt.options.stage,
                 _this.evt.options.region,
                 regionVars.resourcesStackName ? regionVars.resourcesStackName : null,
-                templateUrl)
+                templateUrl,
+                regionVars.preventResourceDeletes,
+                _this.evt.options.allowDeletes)
                 .then(cfData => {
 
                   // If string, log output

--- a/lib/utils/aws/CloudFormation.js
+++ b/lib/utils/aws/CloudFormation.js
@@ -18,6 +18,28 @@ let BbPromise = require('bluebird'),
 // Promisify fs module. This adds "Async" to the end of every method
 BbPromise.promisifyAll(fs);
 
+let allowAllPolicy = JSON.stringify({
+  "Statement" : [
+    {
+      "Effect" : "Allow",
+      "Action" : "Update:*",
+      "Principal": "*",
+      "Resource" : "*"
+    }
+  ]
+});
+
+let preventDeletesPolicy = JSON.stringify({
+  "Statement" : [
+    {
+      "Effect" : "Allow",
+      "NotAction" : ["Update:Replace", "Update:Delete"],
+      "Principal": "*",
+      "Resource" : "*"
+    }
+  ]
+});
+
 /**
  * Export
  */
@@ -130,7 +152,7 @@ module.exports = function(config) {
    * Create Or Update Resources Stack
    */
 
-  CloudFormation.sCreateOrUpdateResourcesStack = function(project, stage, region, stackName, templateUrl) {
+  CloudFormation.sCreateOrUpdateResourcesStack = function(project, stage, region, stackName, templateUrl, preventDeletesByDefault, allowDeletesDuringUpdate) {
 
     let _this = this;
 
@@ -140,7 +162,8 @@ module.exports = function(config) {
         'CAPABILITY_IAM'
       ],
       Parameters:  [],
-      TemplateURL: templateUrl
+      TemplateURL: templateUrl,
+      StackPolicyBody: preventDeletesByDefault ? preventDeletesPolicy : allowAllPolicy
     };
 
     // Helper function to create Stack
@@ -165,6 +188,10 @@ module.exports = function(config) {
       .then(function(data) {
 
         params.StackName = stackName;
+
+        if (allowDeletesDuringUpdate) {
+          params.StackPolicyDuringUpdateBody = allowAllPolicy;
+        }
 
         // Update stack
         return CloudFormation.updateStackPromised(params);


### PR DESCRIPTION
Add the option to prevent deletion of resources by default using stack
policies. This protects against surprises during a resource deploy if
you make changes that you didn't realize were going to delete resources.

You could define finer grained update policies at the module level but a
simple global check is effective for many common cases.